### PR TITLE
Fix file and dict upload

### DIFF
--- a/src/pocketbase/services/base.py
+++ b/src/pocketbase/services/base.py
@@ -1,3 +1,4 @@
+import json
 from typing import TYPE_CHECKING
 
 from httpx import Request, Response
@@ -66,11 +67,16 @@ class Service:
             data, sfiles = transform(body)
             files.extend(sfiles)
 
+        # convert the casted data back to str (happens inside transform)
+        for key, value in (data or {}).items():
+            if isinstance(value, dict | list):
+                data[key] = json.dumps(value)  # type: ignore
+
         return self._in.client.build_request(
             url=self._build_url(path),
             method=options.get("method", "GET"),
             json=body,
-            data=data,
+            data=data,  # on multipart with files we have to send it via data
             files=files,  # type: ignore
             params=options.get("params"),
             headers=headers,


### PR DESCRIPTION
### Checklist

* [x] I have read the Contribution Guidelines
* [x] I have read and agree to the Code of Conduct
* [x] I have read and agree that my contributions will be included under the project license
* [x] I have added a description of my changes and why I want them _or_ linked the relevant pull request below
* [x] I have ran the formatter, linter and tests locally and ensured they give their all green
* [x] If contributing new code: I've ensured my new code is covered sufficiently by unit and integration tests

### Description of Changes

When a FileUpload is made in combination with a list or a dict. The multipart transform cast it to json. We have to dump it again to make it work.

### Related Issues

https://github.com/knowsuchagency/pocketbase_orm/commit/c1bfc99a7c6166edb6f4d0851f577b9efbccdbe7
